### PR TITLE
Added THN132N support

### DIFF
--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -592,16 +592,24 @@ static int oregon_scientific_v2_1_parser(uint8_t bb[BITBUF_ROWS][BITBUF_COLS]) {
 	   fprintf(stderr, "Weather Sensor RGR968   Rain Gauge  Rain Rate: %2.0fmm/hr Total Rain %3.0fmm\n", rain_rate, total_rain);
 	   }
 	   return 1;
-        } else if (sensor_id == 0xec40) {
-           if (  validate_os_v2_message(msg, 153, num_valid_v2_bits, 12) == 0) {
-               int  channel = ((msg[2] >> 4)&0x0f);
-               if (channel == 4)
-                   channel = 3; // sensor 3 channel number is 0x04
-               float temp_c = get_os_temperature(msg, sensor_id);
-               if (sensor_id == 0xec40) fprintf(stderr, "Thermo Sensor THR228N Channel %d ", channel);
-               fprintf(stderr, "Temp: %3.1fâC  %3.1fâF\n", temp_c, ((temp_c*9)/5)+32);
-           }
-	   return 1;
+	} else if (sensor_id == 0xec40 && num_valid_v2_bits==153) {
+		if (  validate_os_v2_message(msg, 153, num_valid_v2_bits, 12) == 0) {
+			int  channel = ((msg[2] >> 4)&0x0f);
+			if (channel == 4)
+				channel = 3; // sensor 3 channel number is 0x04
+			float temp_c = get_os_temperature(msg, sensor_id);
+			if (sensor_id == 0xec40) fprintf(stderr, "Thermo Sensor THR228N Channel %d ", channel);
+			fprintf(stderr, "Temp: %3.1fâC  %3.1fâF\n", temp_c, ((temp_c*9)/5)+32);
+		}
+		return 1;
+	} else if (sensor_id == 0xec40 && num_valid_v2_bits==129) {
+		if (  validate_os_v2_message(msg, 129, num_valid_v2_bits, 12) == 0) {
+			int  channel = ((msg[2] >> 4)&0x0f);
+			float temp_c = get_os_temperature(msg, sensor_id);
+			if (sensor_id == 0xec40) fprintf(stderr, "Thermo Sensor THN132N Channel %d, ", channel);
+			fprintf(stderr, "Temp: %3.1fC  %3.1fF\n", temp_c, ((temp_c*9)/5)+32);
+		}
+		return 1;
 	} else if (num_valid_v2_bits > 16) {
 fprintf(stderr, "%d bit message received from unrecognized Oregon Scientific v2.1 sensor with device ID %x.\n", num_valid_v2_bits, sensor_id);
 fprintf(stderr, "Message: "); for (i=0 ; i<20 ; i++) fprintf(stderr, "%02x ", msg[i]); fprintf(stderr,"\n\n");

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -605,9 +605,10 @@ static int oregon_scientific_v2_1_parser(uint8_t bb[BITBUF_ROWS][BITBUF_COLS]) {
 	} else if (sensor_id == 0xec40 && num_valid_v2_bits==129) {
 		if (  validate_os_v2_message(msg, 129, num_valid_v2_bits, 12) == 0) {
 			int  channel = ((msg[2] >> 4)&0x0f);
+			unsigned char rolling_code = ((msg[2] << 4)&0xF0) | ((msg[3] >> 4)&0x0F);
 			float temp_c = get_os_temperature(msg, sensor_id);
-			if (sensor_id == 0xec40) fprintf(stderr, "Thermo Sensor THN132N Channel %d, ", channel);
-			fprintf(stderr, "Temp: %3.1fC  %3.1fF\n", temp_c, ((temp_c*9)/5)+32);
+			if (sensor_id == 0xec40) fprintf(stderr, "Thermo Sensor THN132N, Channel %d, Rolling-code 0x%0X, ", channel, rolling_code);
+			fprintf(stderr, "TempC %3.1f, TempF %3.1f\n", temp_c, ((temp_c*9)/5)+32);
 		}
 		return 1;
 	} else if (num_valid_v2_bits > 16) {


### PR DESCRIPTION
Hi, 

added some code to distinguished THR228N from THN132N (as it seems they both share 0xEC40 sensor code). I tested the code with THN132N sensor and it works. 

Regards,
Andrea

// quote test
$ ./src/rtl_433
Registering protocol[01] Rubicson Temperature Sensor
Registering protocol[02] Prologue Temperature Sensor
Registering protocol[03] Silvercrest Remote Control
Registering protocol[04] ELV EM 1000
Registering protocol[05] ELV WS 2000
Registering protocol[06] Waveman Switch Transmitter
Registering protocol[07] Steffen Switch Transmitter
Registering protocol[08] Oregon Scientific Weather Sensor
Found 1 device(s):
  0:  Realtek, RTL2838UHIDIR, SN: 00000001

Using device 0: ezcap USB 2.0 DVB-T/DAB/FM dongle
Found Rafael Micro R820T tuner
Exact sample rate is: 250000.000414 Hz
Sample rate set to 250000.
Sample rate decimation set to 0. 250000->250000
Bit detection level set to 10000.
Tuner gain set to Auto.
Reading samples in async mode...
Tuned to 433920000 Hz.
Thermo Sensor THN132N Channel 1, Temp: 26.7C  80.1F
Thermo Sensor THN132N Channel 1, Temp: 26.7C  80.1F
Thermo Sensor THN132N Channel 1, Temp: 26.6C  79.9F
Thermo Sensor THN132N Channel 1, Temp: 26.6C  79.9F
Thermo Sensor THN132N Channel 1, Temp: 26.5C  79.7F
Thermo Sensor THN132N Channel 1, Temp: 26.5C  79.7F
Thermo Sensor THN132N Channel 1, Temp: 26.4C  79.5F
Thermo Sensor THN132N Channel 1, Temp: 26.4C  79.5F
...
// end quote test
